### PR TITLE
Convert filename-based JarArchiveModels to file checks

### DIFF
--- a/pkg/conversion/convert.go
+++ b/pkg/conversion/convert.go
@@ -104,7 +104,7 @@ func convertWindupWhenToAnalyzer(windupWhen windup.When, where map[string]string
 			// JarArchiveModel is a special case for deps
 			// that are actually included in a lib folder as jars
 			if gq.Discriminator == "JarArchiveModel" {
-				conditions = append(conditions, map[string]interface{}{"java.dependency": convertWindupGraphQueryJarArchiveModel(gq)})
+				conditions = append(conditions, convertWindupGraphQueryJarArchiveModel(gq))
 			} else if gq.Discriminator == "TechnologyTagModel" {
 				conditions = append(conditions, map[string]interface{}{"builtin.hasTags": []string{gq.Property.Value}})
 			}
@@ -364,10 +364,18 @@ func convertWindupDependencyToAnalyzer(windupDependency windup.Dependency) map[s
 }
 
 func convertWindupGraphQueryJarArchiveModel(gq windup.Graphquery) map[string]interface{} {
-	m := map[string]interface{}{
-		"nameregex": gq.Property.Value,
+
+	if gq.Property.Name == "fileName" {
+		return map[string]interface{}{
+			"builtin.file": gq.Property.Value,
+		}
 	}
-	return m
+
+	return map[string]interface{}{
+		"java.dependency": map[string]string{
+			"nameregex": gq.Property.Value,
+		},
+	}
 }
 
 // TODO handle perform fully

--- a/pkg/execution/execute.go
+++ b/pkg/execution/execute.go
@@ -182,7 +182,7 @@ func ExecuteRulesets(rulesets []windup.Ruleset, datadir string) (string, string,
 		"sourceFile": sourceFiles,
 	}
 	writeYAML(debugInfo, filepath.Join(dir, "debug.yaml"))
-	stdout, err := cmd.Output()
+	stdout, err := cmd.CombinedOutput()
 	if exitError, ok := err.(*exec.ExitError); ok {
 		fmt.Printf("\n\n UNABLE TO RUN: %v\n\n\n", exitError)
 	}


### PR DESCRIPTION
Analyzer PR: 123

I'm not sure if this is the right thing to do, we may need to instead make changes in the analyzer-lsp/dependency work, but not totally sure what that would look like generically.